### PR TITLE
Remove unused import + add declare strict

### DIFF
--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * PHP micro library to resize, thumbnail or apply filters to your images
  *
@@ -7,8 +9,6 @@
  **/
 
 namespace Imagine;
-
-use phpDocumentor\Reflection\PseudoTypes\True_;
 
 class Imagine
 {


### PR DESCRIPTION
This import `phpDocumentor\Reflection\PseudoTypes\True_` does not seems to be used and does not seems to be needed. Also there is no such dependency in the composer.json so it can be removed safely.