### PR TITLE
release/2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $image->setDPI(96);
 $image->setQuality(90);
 $image->setFit('cover');
 $image->setPosition('left', 'top');
-$image->setBackgroundFromArray(array('r' => 255, 'g' => 255, 'b' => 255, 'a' => 1));
+$image->setBackgroundFromRGBA(255, 255, 255, 1);
 $image->setBackgroundFromHexa('#ffaaff');
 $image->setBackgroundTransparent();
 $image->setBackgroundMainColor();
@@ -184,12 +184,7 @@ $image = new Imagine('./tests/assets/file-transparent.png');
 $image->setWidth(300);
 $image->setHeight(300);
 $image->setFit('contain');
-$image->setBackgroundFromArray(array(
-  'r' => 255,
-  'g' => 0,
-  'b' => 0,
-  'a' => 1,
-));
+$image->setBackgroundFromRGBA(255, 0, 0, 1);
 $image->setType('jpg');
 $image->save('./doc/img/example-08.jpg');
 ```

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -18,13 +18,13 @@ class Imagine
     private $srcHeight = 0;
     private $srcMime = '';
     private $srcType = '';
-    private $srcDPI = array(0, 0);
+    private $srcDPI = array('x' => 0, 'y' => 0);
     private $dist = null;
     private $distWidth = 0;
     private $distHeight = 0;
     private $distMime = '';
     private $distType = '';
-    private $distDPI = array(0, 0);
+    private $distDPI = array('x' => 0, 'y' => 0);
     private $thumbWidth = 0;
     private $thumbHeight = 0;
     private $quality = 100;
@@ -206,7 +206,10 @@ class Imagine
             return false;
         }
 
-        $this->srcDPI = $dpi ?? array(72, 72);
+        $this->srcDPI =array(
+            'x' => $dpi[0],
+            'y' => $dpi[1],
+        );
 
         return true;
     }
@@ -379,7 +382,10 @@ class Imagine
         $dpiX = ($dpiX <= 0) ? 72 : $dpiX;
         $dpiY = ($dpiY <= 0) ? $dpiX : $dpiY;
 
-        $this->distDPI = array($dpiX, $dpiY);
+        $this->distDPI = array(
+            'x' => $dpiX,
+            'y' => $dpiY,
+        );
 
         return true;
     }
@@ -401,7 +407,7 @@ class Imagine
      */
     public function getDistDPI(): array
     {
-        if (empty($this->distDPI[0]) || empty($this->distDPI[1])) {
+        if (empty($this->distDPI['x']) || empty($this->distDPI['y'])) {
             return $this->srcDPI;
         }
 
@@ -805,8 +811,8 @@ class Imagine
             return false;
         }
 
-        if (empty($this->distDPI[0]) || empty($this->distDPI[1])) {
-            $this->distDPI = $this->srcDPI;
+        if (empty($this->distDPI['x']) || empty($this->distDPI['y'])) {
+            $this->setDPI($this->srcDPI['x'], $this->srcDPI['y']);
         }
 
         // Set the final extension if there is no conversion done on the file
@@ -814,7 +820,7 @@ class Imagine
             $this->setType($this->srcType);
         }
 
-        $dpi = \imageresolution($this->dist, $this->distDPI[0], $this->distDPI[1]);
+        $dpi = \imageresolution($this->dist, $this->distDPI['x'], $this->distDPI['y']);
 
         if (empty($dpi)) {
             throw new \Exception('There is a problem when processing the destination file');

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -571,20 +571,33 @@ class Imagine
     public function setBackgroundMainColor(): bool
     {
         try {
-            $image = $this->src;
-
-            if (empty($image)) {
+            if (empty($this->src)) {
                 throw new \Exception('There was an error when filling in the background color');
                 return false;
             }
 
             $thumb = @\imagecreatetruecolor(1, 1);
-            @\imagecopyresampled($thumb, $image, 0, 0, 0, 0, 1, 1, \imagesx($image), \imagesy($image));
+            @\imagecopyresampled($thumb, $this->src, 0, 0, 0, 0, 1, 1, $this->srcWidth, $this->srcHeight);
 
-            $mainColor = @strtolower(dechex(\imagecolorat($thumb, 0, 0)));
-            $mainColor = '#' . $mainColor;
+            $index = @\imagecolorat($thumb, 0, 0);
 
-            \imagedestroy($thumb);
+            if ($index === false) {
+                @\imagedestroy($thumb);
+                throw new \Exception('There was an error when filling in the background color');
+                return false;
+            }
+
+            $mainColor = @strtolower(@dechex($index));
+
+            if (empty($mainColor)) {
+                @\imagedestroy($thumb);
+                throw new \Exception('There was an error when filling in the background color');
+                return false;
+            }
+
+            $mainColor = '#' . (string) $mainColor;
+
+            @\imagedestroy($thumb);
 
             $this->background = $this->getHexaToRGBA($mainColor);
 

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -28,7 +28,7 @@ class Imagine
     private $thumbWidth = 0;
     private $thumbHeight = 0;
     private $quality = 100;
-    private $fit = 'stretch';
+    private $fit = 'contain';
     private $position = array('x' => 'center', 'y' => 'center');
     private $filters = array();
     private $background = array('r' => 255, 'g' => 255, 'b' => 255, 'a' => 1);
@@ -966,7 +966,7 @@ class Imagine
         int $srcHeight = 0,
         int $thumbWidth = 0,
         int $thumbHeight = 0,
-        string $fit = 'stretch'
+        string $fit = ''
     ): array {
         $distWidth = 0;
         $distHeight = 0;

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -206,7 +206,7 @@ class Imagine
             return false;
         }
 
-        $this->srcDPI =array(
+        $this->srcDPI = array(
             'x' => $dpi[0],
             'y' => $dpi[1],
         );

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -29,7 +29,7 @@ class Imagine
     private $thumbHeight = 0;
     private $quality = 100;
     private $fit = 'stretch';
-    private $position = array('center', 'center');
+    private $position = array('x' => 'center', 'y' => 'center');
     private $filters = array();
     private $background = array('r' => 255, 'g' => 255, 'b' => 255, 'a' => 1);
     private $isInterlace = false;
@@ -486,7 +486,10 @@ class Imagine
             return false;
         }
 
-        $this->position = array($x, $y);
+        $this->position = array(
+            'x' => $x,
+            'y' => $y,
+        );
 
         return true;
     }
@@ -864,20 +867,20 @@ class Imagine
         // We do the calculation only if we are in "contain" or "cover".
         if ($this->fit === 'contain' || $this->fit === 'cover') {
             // X calcul
-            if ($this->position[0] === 'left') {
+            if ($this->position['x'] === 'left') {
                 $positionX = 0;
-            } elseif ($this->position[0] === 'center') {
+            } elseif ($this->position['x'] === 'center') {
                 $positionX = (int) (($this->thumbWidth - $this->distWidth) / 2);
-            } elseif ($this->position[0] === 'right') {
+            } elseif ($this->position['x'] === 'right') {
                 $positionX = (int) ($this->thumbWidth - (int) $this->distWidth);
             }
 
             // Y Calcul
-            if ($this->position[1] === 'top') {
+            if ($this->position['y'] === 'top') {
                 $positionY = 0;
-            } elseif ($this->position[1] === 'center') {
+            } elseif ($this->position['y'] === 'center') {
                 $positionY = (int) (($this->thumbHeight - $this->distHeight) / 2);
-            } elseif ($this->position[1] === 'bottom') {
+            } elseif ($this->position['y'] === 'bottom') {
                 $positionY = (int) ($this->thumbHeight - (int) $this->distHeight);
             }
         }

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -505,28 +505,20 @@ class Imagine
     }
 
     /**
-     * Saves the background color of the destination image with an "rgba" array
+     * Saves the background color of the destination image with "rgba" values
      *
-     * @param array $background Array in "rgba"
+     * @param integer $r Red
+     * @param integer $g Green
+     * @param integer $b Blue
+     * @param float $a Alpha
      * @return boolean
      */
-    public function setBackgroundFromArray(array $background = array()): bool
+    public function setBackgroundFromRGBA(int $r = 255, int $g = 255, int $b = 255, float $a = 1): bool
     {
-        if (!is_array($background)) {
-            return false;
-        }
-
-        $bg = array_merge(array(
-            'r' => 255,
-            'g' => 255,
-            'b' => 255,
-            'a' => 1,
-        ), $background);
-
-        $this->background['r'] = $bg['r'] >= 0 && $bg['r'] <= 255 ? (int) $bg['r'] : 255;
-        $this->background['g'] = $bg['g'] >= 0 && $bg['g'] <= 255 ? (int) $bg['g'] : 255;
-        $this->background['b'] = $bg['b'] >= 0 && $bg['b'] <= 255 ? (int) $bg['b'] : 255;
-        $this->background['a'] = $bg['a'] >= 0 && $bg['a'] <= 1 ? (float) $bg['a'] : 1;
+        $this->background['r'] = $r >= 0 && $r <= 255 ? $r : 255;
+        $this->background['g'] = $g >= 0 && $g <= 255 ? $g : 255;
+        $this->background['b'] = $b >= 0 && $b <= 255 ? $b : 255;
+        $this->background['a'] = $a >= 0 && $a <= 1 ? $a : 1;
 
         return true;
     }

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -1057,10 +1057,12 @@ class Imagine
     {
         if ($isSrcMustDestroy) {
             @\imagedestroy($this->src);
+            $this->src = null;
         }
 
         if ($isDistMustDestroy) {
             @\imagedestroy($this->dist);
+            $this->dist = null;
         }
 
         return !$isSrcMustDestroy && !$isDistMustDestroy ? false : true;

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -153,8 +153,8 @@ class Imagine
             return false;
         }
 
-        $this->srcWidth = $info[0];
-        $this->srcHeight = $info[1];
+        $this->srcWidth = (int) $info[0];
+        $this->srcHeight = (int) $info[1];
 
         return true;
     }
@@ -245,7 +245,12 @@ class Imagine
      */
     public function getDistWidth(): int
     {
-        $size = $this->calculDistSizeFromThumbSize();
+        $size = $this->calculDistSizeFromThumbSize(
+            $this->thumbWidth,
+            $this->thumbHeight,
+            $this->distWidth,
+            $this->distHeight
+        );
 
         return $size[0];
     }
@@ -284,7 +289,12 @@ class Imagine
      */
     public function getDistHeight(): int
     {
-        $size = $this->calculDistSizeFromThumbSize();
+        $size = $this->calculDistSizeFromThumbSize(
+            $this->thumbWidth,
+            $this->thumbHeight,
+            $this->distWidth,
+            $this->distHeight
+        );
 
         return $size[1];
     }
@@ -769,7 +779,12 @@ class Imagine
      */
     private function render($destination = '', bool $destroySrcGD = true, bool $destroyDistGD = true): bool
     {
-        $size = $this->calculDistSizeFromThumbSize();
+        $size = $this->calculDistSizeFromThumbSize(
+            $this->thumbWidth,
+            $this->thumbHeight,
+            $this->distWidth,
+            $this->distHeight
+        );
 
         $this->thumbWidth = $size[0];
         $this->thumbHeight = $size[1];
@@ -834,18 +849,18 @@ class Imagine
             if ($this->position[0] === 'left') {
                 $position[0] = 0;
             } elseif ($this->position[0] === 'center') {
-                $position[0] = ($this->thumbWidth - $this->distWidth) / 2;
+                $position[0] = (int) (($this->thumbWidth - $this->distWidth) / 2);
             } elseif ($this->position[0] === 'right') {
-                $position[0] = $this->thumbWidth - (int) $this->distWidth;
+                $position[0] = (int) ($this->thumbWidth - (int) $this->distWidth);
             }
 
             // Y Calcul
             if ($this->position[1] === 'top') {
                 $position[1] = 0;
             } elseif ($this->position[1] === 'center') {
-                $position[1] = ($this->thumbHeight - $this->distHeight) / 2;
+                $position[1] = (int) (($this->thumbHeight - $this->distHeight) / 2);
             } elseif ($this->position[1] === 'bottom') {
-                $position[1] = $this->thumbHeight - (int) $this->distHeight;
+                $position[1] = (int) ($this->thumbHeight - (int) $this->distHeight);
             }
         }
 
@@ -930,20 +945,19 @@ class Imagine
      *
      * @return array
      */
-    private function calculDistSizeFromThumbSize(): array
-    {
-        $thumbWidth = $this->thumbWidth;
-        $thumbHeight = $this->thumbHeight;
-        $distWidth = $this->distWidth;
-        $distHeight = $this->distHeight;
-
+    private function calculDistSizeFromThumbSize(
+        int $thumbWidth = 0,
+        int $thumbHeight = 0,
+        int $distWidth = 0,
+        int $distHeight = 0
+    ): array {
         // On vérifit si c'est un redimmenssionnement
         if ($thumbWidth > 0 xor $thumbHeight > 0) {
             // On enregistre la taille une fois redimmenssionné
             if ($thumbWidth) {
-                $thumbHeight = $this->srcHeight * ($thumbWidth / $this->srcWidth);
+                $thumbHeight = (int) ($this->srcHeight * ($thumbWidth / $this->srcWidth));
             } else {
-                $thumbWidth = $this->srcWidth * ($thumbHeight / $this->srcHeight);
+                $thumbWidth = (int) ($this->srcWidth * ($thumbHeight / $this->srcHeight));
             }
 
             $distWidth = $thumbWidth;
@@ -955,58 +969,53 @@ class Imagine
                 $distWidth = $thumbWidth;
                 $distHeight = $thumbHeight;
             } elseif ($this->fit === 'contain' || $this->fit === 'cover') {
-                $fitAllowed = array(
-                    'contain' => array(
-                        $thumbWidth > $thumbHeight &&
-                        $this->srcWidth > $this->srcHeight &&
-                        ($this->srcWidth * $thumbHeight) / $this->srcHeight < $thumbWidth
-                            ? true
-                            : false,
-                        $thumbWidth > $thumbHeight && $this->srcWidth <= $this->srcHeight ? true : false,
-                        $thumbWidth <= $thumbHeight &&
-                        $this->srcWidth < $this->srcHeight &&
-                        ($this->srcWidth * $thumbHeight) / $this->srcHeight < $thumbWidth
-                            ? true
-                            : false,
-                        $thumbWidth === $thumbHeight && $this->srcWidth === $this->srcHeight ? true : false
-                    ),
-                    'cover' => array(
-                        $thumbWidth > $thumbHeight &&
-                        $this->srcWidth > $this->srcHeight &&
-                        ($this->srcWidth * $thumbHeight) / $this->srcHeight > $thumbWidth
-                            ? true
-                            : false,
-                        $thumbWidth <= $thumbHeight && $this->srcWidth > $this->srcHeight ? true : false,
-                        $thumbWidth < $thumbHeight &&
-                        $this->srcWidth <= $this->srcHeight &&
-                        ($this->srcWidth * $thumbHeight) / $this->srcHeight > $thumbWidth
-                            ? true
-                            : false,
-                        $thumbWidth === $thumbHeight && $this->srcWidth === $this->srcHeight ? true : false
-                    )
+                $isArrayContain = array(
+                    $thumbWidth > $thumbHeight &&
+                    $this->srcWidth > $this->srcHeight &&
+                    ($this->srcWidth * $thumbHeight) / $this->srcHeight < $thumbWidth,
+                    $thumbWidth > $thumbHeight &&
+                    $this->srcWidth <= $this->srcHeight,
+                    $thumbWidth <= $thumbHeight &&
+                    $this->srcWidth < $this->srcHeight &&
+                    ($this->srcWidth * $thumbHeight) / $this->srcHeight < $thumbWidth,
+                    $thumbWidth === $thumbHeight &&
+                    $this->srcWidth === $this->srcHeight,
+                );
+
+                $isArrayCover = array(
+                    $thumbWidth > $thumbHeight &&
+                    $this->srcWidth > $this->srcHeight &&
+                    ($this->srcWidth * $thumbHeight) / $this->srcHeight > $thumbWidth,
+                    $thumbWidth <= $thumbHeight &&
+                    $this->srcWidth > $this->srcHeight,
+                    $thumbWidth < $thumbHeight &&
+                    $this->srcWidth <= $this->srcHeight &&
+                    ($this->srcWidth * $thumbHeight) / $this->srcHeight > $thumbWidth,
+                    $thumbWidth === $thumbHeight &&
+                    $this->srcWidth === $this->srcHeight,
                 );
 
                 // Si c'est le cas 1
                 if (
-                    (in_array(true, $fitAllowed['contain']) && $this->fit === 'contain') ||
-                    (in_array(true, $fitAllowed['cover']) && $this->fit === 'cover')
+                    (in_array(true, $isArrayContain) && $this->fit === 'contain') ||
+                    (in_array(true, $isArrayCover) && $this->fit === 'cover')
                 ) {
                     // On redimmensionne 'img' d'abord par sa largeur
-                    $distWidth = ($this->srcWidth * $thumbHeight) / $this->srcHeight;
-                    $distHeight = ($this->srcHeight * $distWidth) / $this->srcWidth;
+                    $distWidth = (int) (($this->srcWidth * $thumbHeight) / $this->srcHeight);
+                    $distHeight = (int) (($this->srcHeight * $distWidth) / $this->srcWidth);
                 } else {
                     // Si c'est le cas 2
 
                     // On redimmensionne 'img' d'abord par sa hauteur
-                    $distHeight = ($this->srcHeight * $thumbWidth) / $this->srcWidth;
-                    $distWidth = ($this->srcWidth * $distHeight) / $this->srcHeight;
+                    $distHeight = (int) (($this->srcHeight * $thumbWidth) / $this->srcWidth);
+                    $distWidth = (int) (($this->srcWidth * $distHeight) / $this->srcHeight);
                 }
             }
         } else {
             // Sinon on donne les même dimension que l'image original
 
-            $distWidth = $thumbWidth = $this->srcWidth;
-            $distHeight = $thumbHeight = $this->srcHeight;
+            $distWidth = $thumbWidth = (int) $this->srcWidth;
+            $distHeight = $thumbHeight = (int) $this->srcHeight;
         }
 
         return array(

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -940,7 +940,7 @@ class Imagine
         } elseif ($this->distType === 'webp') {
             $isCreate = \imagewebp($this->dist, $destination, $this->quality);
         } elseif ($this->distType === 'bmp') {
-            $isCreate = \imagebmp($this->dist, $destination, $this->quality);
+            $isCreate = \imagebmp($this->dist, $destination, $this->quality === 100);
         } else {
             $this->destroyTempImg($destroySrcGD, $destroyDistGD);
             return false;


### PR DESCRIPTION
## Changed
- Restructure the 'setBackgroundMainColor' function
- Made some structuring improvements
- Change the nomenclature of values for DPI
- Change the nomenclature of values for position
- Change the default way of stretching
- Change the function 'setBackgroundFromArray' to 'setBackgroundFromRGBA'

## Fixed
- Fixes a problem with incorrectly typed values in resizing calculations
- Fixes a bug when creating a BMP
- Fixes bugs in the MIME of the destination image
- Resets GD resources to null when destroyed